### PR TITLE
Fix invalid memory access

### DIFF
--- a/src/print.c
+++ b/src/print.c
@@ -94,7 +94,7 @@ void print_file_matches(const char *path, const char *buf, const size_t buf_len,
 
     context_prev_lines = ag_calloc(sizeof(char *), (opts.before + 1));
 
-    for (i = 0; i <= buf_len && (cur_match < matches_len || lines_since_last_match <= opts.after); i++) {
+    for (i = 0; i < buf_len && (cur_match < matches_len || lines_since_last_match <= opts.after); i++) {
         if (cur_match < matches_len && i == matches[cur_match].start) {
             in_a_match = TRUE;
             /* We found the start of a match */


### PR DESCRIPTION
I've noticed occasional segfaults from accessing beyond the end of
the file buffer. This adds the correct bound to index variable i.
